### PR TITLE
feat-v0: chat stream using embedbase cloud

### DIFF
--- a/src/EmbedbaseClient.ts
+++ b/src/EmbedbaseClient.ts
@@ -10,7 +10,7 @@ import type {
   BatchAddDocument,
   ClientDatasets,
 } from './types'
-import { camelize } from './utils'
+import { camelize, stream } from './utils'
 
 /**
  * Embedbase Client.
@@ -109,6 +109,18 @@ export default class EmbedbaseClient {
       id: result.id,
       status: data.error ? 'error' : 'success',
     }))
+  }
+
+  public async * chat(prompt: string): AsyncGenerator<string> {
+    const url = 'https://app.embedbase.xyz/api/chat'
+    // const url = 'http://localhost:3000/api/chat'
+    for await (const res of stream(
+      url,
+      JSON.stringify({ prompt }),
+      this.headers,
+    )) {
+      yield res
+    }
   }
 
   dataset(dataset: string): {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,3 +26,34 @@ const camelCase = (str: string) => {
     return $1.toUpperCase().replace('-', '').replace('_', '')
   })
 }
+
+export async function* stream (url: string, body: string, headers: { [key: string]: string }) {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: headers,
+    body: body,
+  })
+
+  if (!response.ok) {
+    // assuming the error is a JSON object
+    const message = await response.json()
+    throw new Error(message.error)
+  }
+
+  // This data is a ReadableStream
+  const data = response.body
+  if (!data) {
+    return
+  }
+
+  const reader = data.getReader()
+  const decoder = new TextDecoder()
+  let done = false
+
+  while (!done) {
+    const { value, done: doneReading } = await reader.read()
+    done = doneReading
+    const chunkValue = decoder.decode(value)
+    yield chunkValue
+  }
+}

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -163,3 +163,9 @@ describe('Check if the client is able to fetch data', () => {
     expect(datasetIds).toContain('baz')
   })
 })
+
+test('should be able to chat', async () => {
+  for await (const res of embedbase.chat('hello')) {
+    console.log(res)
+  }
+})


### PR DESCRIPTION
- Still exploration state
- Should we copy openai api?
- Or provide a higher level api? (I like [async generator](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html#the-for-await-of-statement))
- not sure how to handle error there

### TLDR

```ts
for await (const res of embedbase.chat('a unicorn is')) {
    console.log(res)
}
```
> " a", "legendary", " animal" ...

later could be...

```ts
// where domain is a collection of datasets automatically selected by LLM
for await (const res of embedbase.domain('web3').chat('how can i run an eth node on my coffee machine?')) {
    console.log(res)
}
// or
for await (const res of embedbase.domain('my-ecommerce-products')
    .chat('what is the best coffee machine to prepare egg coffees fast?')) {
    console.log(res)
}
```
